### PR TITLE
3.x: Fetch the real client IP address in proxy setups

### DIFF
--- a/Classes/SyslogBackend.php
+++ b/Classes/SyslogBackend.php
@@ -64,7 +64,7 @@ class SyslogBackend extends \TYPO3\Flow\Log\Backend\AbstractBackend {
 
 		// + remote addr, if requested
 		if ($this->logIpAddress === TRUE) {
-		    $ip = $this->getClientIPAddress();
+			$ip = $this->getClientIPAddress();
 			$output .= sprintf(' (%s)', $ip ? $ip : '-');
 		}
 
@@ -76,28 +76,28 @@ class SyslogBackend extends \TYPO3\Flow\Log\Backend\AbstractBackend {
 		syslog($severity, $output);
 	}
 
-    /**
-     * Fetches the client IP address, also taking care of upstream proxies, if needed
-     *
-     * @return string|null
-     */
-    function getClientIPAddress() {
-        if (isset($_SERVER['REMOTE_ADDR'])) {
-            $remoteAddr = new \IpUtils\Address\IPv4($_SERVER['REMOTE_ADDR']);
+	/**
+	 * Fetches the client IP address, also taking care of upstream proxies, if needed
+	 *
+	 * @return string|null
+	 */
+	function getClientIPAddress() {
+		if (isset($_SERVER['REMOTE_ADDR'])) {
+			$remoteAddr = new \IpUtils\Address\IPv4($_SERVER['REMOTE_ADDR']);
 
-            if (!$remoteAddr) { return null; }
+			if (!$remoteAddr) { return null; }
 
-            if (!$remoteAddr->isPrivate()) {
-                return $remoteAddr->getExpanded();
-            }
-        }
+			if (!$remoteAddr->isPrivate()) {
+				return $remoteAddr->getExpanded();
+			}
+		}
 
-        if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
-            return $_SERVER['HTTP_X_FORWARDED_FOR'];
-        }
+		if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+			return $_SERVER['HTTP_X_FORWARDED_FOR'];
+		}
 
-        return null;
-    }
+		return null;
+	}
 
 	/**
 	 * Carries out all actions necessary to cleanly close the logging backend, such as

--- a/Classes/SyslogBackend.php
+++ b/Classes/SyslogBackend.php
@@ -81,7 +81,7 @@ class SyslogBackend extends \TYPO3\Flow\Log\Backend\AbstractBackend {
 	 *
 	 * @return string|null
 	 */
-	function getClientIPAddress() {
+	protected function getClientIPAddress() {
 		if (isset($_SERVER['REMOTE_ADDR'])) {
 			$remoteAddr = new \IpUtils\Address\IPv4($_SERVER['REMOTE_ADDR']);
 

--- a/Classes/SyslogBackend.php
+++ b/Classes/SyslogBackend.php
@@ -64,7 +64,8 @@ class SyslogBackend extends \TYPO3\Flow\Log\Backend\AbstractBackend {
 
 		// + remote addr, if requested
 		if ($this->logIpAddress === TRUE) {
-			$output .= sprintf(' (%s)', isset($_SERVER['REMOTE_ADDR']) ? $_SERVER['REMOTE_ADDR'] : '-');
+		    $ip = $this->getClientIPAddress();
+			$output .= sprintf(' (%s)', $ip ? $ip : '-');
 		}
 
 		// + additional data
@@ -74,6 +75,29 @@ class SyslogBackend extends \TYPO3\Flow\Log\Backend\AbstractBackend {
 
 		syslog($severity, $output);
 	}
+
+    /**
+     * Fetches the client IP address, also taking care of upstream proxies, if needed
+     *
+     * @return string|null
+     */
+    function getClientIPAddress() {
+        if (isset($_SERVER['REMOTE_ADDR'])) {
+            $remoteAddr = new \IpUtils\Address\IPv4($_SERVER['REMOTE_ADDR']);
+
+            if (!$remoteAddr) { return null; }
+
+            if (!$remoteAddr->isPrivate()) {
+                return $remoteAddr->getExpanded();
+            }
+        }
+
+        if (isset($_SERVER['HTTP_X_FORWARDED_FOR'])) {
+            return $_SERVER['HTTP_X_FORWARDED_FOR'];
+        }
+
+        return null;
+    }
 
 	/**
 	 * Carries out all actions necessary to cleanly close the logging backend, such as

--- a/composer.json
+++ b/composer.json
@@ -3,10 +3,10 @@
     "type": "typo3-flow-package",
     "license": "MIT",
     "description": "Implements a Flow LogBackend for the local syslog daemon",
-	"require": {
-		"typo3/flow": "3.*",
-		"xrstf/ip-utils": "1.1.*"
-	},
+    "require": {
+        "typo3/flow": "3.*",
+        "xrstf/ip-utils": "1.1.*"
+    },
     "autoload": {
         "psr-4": {
             "CRON\\Flow\\Log\\Backend\\": "Classes"

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,8 @@
     "license": "MIT",
     "description": "Implements a Flow LogBackend for the local syslog daemon",
 	"require": {
-		"typo3/flow": "3.*"
+		"typo3/flow": "3.*",
+		"xrstf/ip-utils": "1.1.*"
 	},
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
This will use the REMOTE_ADDR from PHP only if the IP Address is not
private. If so, it will try to fetch the IP Address from the
$_SERVER['HTTP_X_FORWARDED_FOR'] PHP var.